### PR TITLE
mongosh 0.15.6-testing

### DIFF
--- a/Formula/mongosh.rb
+++ b/Formula/mongosh.rb
@@ -3,8 +3,8 @@ require "language/node"
 class Mongosh < Formula
   desc "MongoDB Shell to connect, configure, query, and work with your MongoDB database"
   homepage "https://github.com/mongodb-js/mongosh#readme"
-  url "https://registry.npmjs.org/@mongosh/cli-repl/-/cli-repl-0.15.5.tgz"
-  sha256 "dbfbe9c5c571d19740f2118f0f023b38836be8ea2e49a1c9be402f108d2900e0"
+  url "https://registry.npmjs.org/@mongosh/cli-repl/-/cli-repl-0.15.6-testing.tgz"
+  sha256 "c8d3eae160a892e32837db3dcae515e843e5383fef52b8141940c8bcf8b6d59f"
   license "Apache-2.0"
 
   bottle do


### PR DESCRIPTION
This PR was created automatically and bumps `mongosh` to the latest published version `0.15.6-testing`.

For additional details see https://github.com/mongodb-js/mongosh/releases/tag/v0.15.6.